### PR TITLE
Set package main property to src/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "repository": "onigoetz/postcss-parcel-css",
   "author": "Stéphane Goetz <onigoetz@onigoetz.ch>",
   "license": "MIT",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "c8 --reporter=lcovonly --reporter=text ava",
     "lint": "semistandard",


### PR DESCRIPTION
Hi !

First of all, thanks for the quick plugin.

The `lib/index.js` file is [missing from the npm package](https://unpkg.com/browse/postcss-parcel-css@0.2.0/), so it can't be imported by doing `require('postcss-parcel-css')`, `require('postcss-parcel-css/src/index')` must be used.

Here I'm setting the main property on `package.json`to `./src/index.js` so that it can be imported directly (except if you want to build it with parcel).